### PR TITLE
Install url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "sass-loader": "^10.0.4",
     "serve-favicon": "2.4.5",
     "style-loader": "^2.0.0",
+    "url-loader": "^4.1.1",
     "webpack": "4.35.0",
     "webpack-cli": "3.3.5"
   },


### PR DESCRIPTION
`url-loader` is used for png's and other files but the package is currently missing. This should fix that.