### PR TITLE
Detect if API_PATH is not set

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -21,7 +21,11 @@ app.use(cors());
 
 router.use("/meals", mealsRouter);
 
-app.use(process.env.API_PATH, router);
+if (process.env.API_PATH) {
+  app.use(process.env.API_PATH, router);
+} else {
+  throw "API_PATH is not set. Remember to set it in your .env file"
+}
 
 // for the frontend. Will first be covered in the react class
 app.use("*", (req, res) => {

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -3,5 +3,5 @@ const app = require("./app");
 const port = parseInt(process.env.PORT, 10) || process.env.API_PORT;
 
 app.listen(port, () => {
-  console.log("Backend api available at /api");
+  console.log(`Backend api available at ${process.env.API_PATH}`);
 });


### PR DESCRIPTION
If API_PATH is not set, the error message can be a bit tricky to understand:

```
TypeError: Cannot read property 'length' of undefined
    at pathtoRegexp (/Users/otoy/dev/hyf/meal-sharing-template/node_modules/path-to-regexp/index.js:63:49)
    at new Layer (/Users/otoy/dev/hyf/meal-sharing-template/node_modules/express/lib/router/layer.js:45:17)
    at Function.use (/Users/otoy/dev/hyf/meal-sharing-template/node_modules/express/lib/router/index.js:464:17)
    at Function.<anonymous> (/Users/otoy/dev/hyf/meal-sharing-template/node_modules/express/lib/application.js:220:21)
    at Array.forEach (<anonymous>)
    at Function.use (/Users/otoy/dev/hyf/meal-sharing-template/node_modules/express/lib/application.js:217:7)
    at Object.<anonymous> (/Users/otoy/dev/hyf/meal-sharing-template/src/backend/app.js:24:5)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
```

This PR tries to help with that by detecting the potential cases when API_PATH is not set. Now the error will look like this:

```
/Users/otoy/dev/hyf/meal-sharing-template/src/backend/app.js:27
  throw 'API_PATH is not set. Remember to set it in your .env file'
  ^
API_PATH is not set. Remember to set it in your .env file
```