### PR TITLE
Update node.js code to use modern ES6 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Website for sharing meals",
   "engines": {
-    "node": "8.11.1"
+    "node": "^21.6.2"
   },
   "scripts": {
     "build": "webpack --mode production",
@@ -15,6 +15,7 @@
   "author": "Benjamin Hughes",
   "license": "MIT",
   "proxy": "http://localhost:5000",
+  "type": "module",
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cors": "^2.8.4",
     "css-loader": "^5.0.0",
     "debug": "~2.6.0",
-    "dotenv": "^4.0.0",
+    "dotenv": "^16.4.5",
     "dotenv-webpack": "^7.1.0",
     "express": "^4.16.4",
     "express-brute": "^1.0.1",

--- a/src/backend/api/meals.js
+++ b/src/backend/api/meals.js
@@ -1,5 +1,5 @@
-import { Router } from "express";
-const router = Router();
+import express from "express";
+const router = express.Router();
 import knex from "../database.js";
 
 router.get("/", async (request, response) => {

--- a/src/backend/api/meals.js
+++ b/src/backend/api/meals.js
@@ -1,6 +1,6 @@
-const express = require("express");
-const router = express.Router();
-const knex = require("../database");
+import { Router } from "express";
+const router = Router();
+import knex from "../database.js";
 
 router.get("/", async (request, response) => {
   try {
@@ -12,4 +12,4 @@ router.get("/", async (request, response) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -2,6 +2,12 @@ import express from "express";
 import path from "path";
 import mealsRouter from "./api/meals.js";
 import cors from "cors";
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const app = express();
 const router = express.Router();

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,12 +1,12 @@
-const express = require("express");
+import express from "express";
+import path from "path";
+import mealsRouter from "./api/meals.js";
+import cors from "cors";
+
 const app = express();
 const router = express.Router();
-const path = require("path");
 
-const mealsRouter = require("./api/meals");
 const buildPath = path.join(__dirname, "../../dist");
-const port = process.env.PORT || 3000;
-const cors = require("cors");
 
 // For week4 no need to look into this!
 // Serve the built client html
@@ -32,4 +32,4 @@ app.use("*", (req, res) => {
   res.sendFile(path.join(`${buildPath}/index.html`));
 });
 
-module.exports = app;
+export default app;

--- a/src/backend/database.js
+++ b/src/backend/database.js
@@ -1,6 +1,5 @@
 import knex from 'knex'
-import 'dotnnet/config';
-
+import 'dotenv/config';
 
 // create connection
 const myKnex = knex({

--- a/src/backend/database.js
+++ b/src/backend/database.js
@@ -1,7 +1,9 @@
-require("dotenv").config();
+import knex from 'knex'
+import 'dotnnet/config';
+
 
 // create connection
-const knex = require("knex")({
+const myKnex = knex({
   client: "mysql2",
   connection: {
     host: process.env.DB_HOST,
@@ -14,8 +16,8 @@ const knex = require("knex")({
 });
 
 // Check that the connection works
-knex.raw("SELECT VERSION()").then(() => {
+myKnex.raw("SELECT VERSION()").then(() => {
   console.log(`connection to db successful!`);
 });
 
-module.exports = knex;
+export default myKnex;

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -1,4 +1,4 @@
-const app = require("./app");
+import app from "./app.js";
 
 const port = parseInt(process.env.PORT, 10) || process.env.API_PORT;
 


### PR DESCRIPTION
Make it easier for students to transition to modern JS and typescript by using the ES6 that's now natively supported in Node.js.

Here is a summary of what I'm updating:

- Bumping node.js version from 8 to 20
- Using "type": "module" to use module instead commonjs in node.js
- Updating all the import/export path to use modern ES6 syntax