### PR TITLE
Deprecating repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ⚠️ DEPRECATED in favour of [hyf-project-template](https://github.com/HackYourFuture-CPH/hyf-project-template)
+
+
 <p align="center">
   <a href="" rel="noopener">
  <img width=200px height=200px src="https://www.hackyourfuture.dk/static/logo-dark.svg" alt="Project logo"></a>


### PR DESCRIPTION
We're in the process of moving towards using https://github.com/HackYourFuture-CPH/hyf-project-template instead.

Deprecating this repo in the meantime.

Some extra context: https://hackyourfuture-cph.slack.com/archives/G41JA7WUS/p1713212545471159

I can also archive this repo after this is merged.